### PR TITLE
Added --checks arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ findcdn list cisa.gov
                                conclude processing, otherwise use default.
   --user_agent=<user_agent>    Set the user agent to use, otherwise
                                use default.
+  --checks=<checks>            Select detection types; possible values: 
+                               cname (c), HTTP headers (h), nameservers (n),
+                               whois data (w). Default: "chnw"
+  --ignore                     Ignores invalid domains and only work with valid
+                               ones (default False, which stops the scan)
 ```
 
 #### Sample Output ####

--- a/src/findcdn/cdnEngine/cdnEngine.py
+++ b/src/findcdn/cdnEngine/cdnEngine.py
@@ -39,6 +39,7 @@ def chef_executor(
     user_agent: str,
     verbosity: bool,
     interactive: bool,
+    checks: str,
 ):
     """Attempt to make the method "threadsafe" by giving each worker its own detector."""
     # Define detector
@@ -53,6 +54,7 @@ def chef_executor(
             timeout=math.ceil(timeout * 0.4),
             agent=user_agent,
             interactive=interactive,
+            checks = checks,
         )
     except Exception as e:
         # Incase some uncaught error somewhere
@@ -75,6 +77,7 @@ class Chef:
         user_agent: str,
         interactive: bool = False,
         verbose: bool = False,
+        checks: str = "chnw",
     ):
         """Give the chef the pot to use."""
         self.pot: DomainPot = pot
@@ -83,6 +86,7 @@ class Chef:
         self.timeout: int = timeout
         self.agent = user_agent
         self.interactive = interactive
+        self.checks = checks
 
         # Determine thread count
         if threads and threads != 0:
@@ -129,6 +133,7 @@ class Chef:
                     self.agent,
                     self.verbose,
                     self.interactive,
+                    self.checks,
                 )
                 for domain in newpot
             }
@@ -178,13 +183,14 @@ def run_checks(
     interactive: bool = False,
     verbose: bool = False,
     double: bool = False,
+    checks: str = "chnw",
 ) -> Tuple[List[detectCDN.Domain], int]:
     """Orchestrate the use of DomainPot and Chef."""
     # Our domain pot
     dp = DomainPot(domains)
 
     # Our chef to manage pot
-    chef = Chef(dp, threads, timeout, user_agent, interactive, verbose)
+    chef = Chef(dp, threads, timeout, user_agent, interactive, verbose, checks)
 
     # Run analysis for all domains
     cnt = chef.run_checks(double)

--- a/src/findcdn/cdnEngine/detectCDN/cdn_check.py
+++ b/src/findcdn/cdnEngine/detectCDN/cdn_check.py
@@ -9,6 +9,7 @@ from http.client import RemoteDisconnected
 from ssl import CertificateError, SSLError
 from typing import List
 from urllib import request as request
+from urllib import parse
 from urllib.error import URLError
 
 # Third-Party Libraries
@@ -23,6 +24,41 @@ from .cdn_err import NoIPaddress
 # Global variables
 LIFETIME = 10
 
+
+class RedirectFilter(request.HTTPRedirectHandler):
+
+    def redirect_request(self, req, fp, code, msg, hdrs, newurl):
+        newhost = parse.urlparse(newurl).netloc
+        # if the original and redirected hostname are the same
+        if req.host == newhost:
+            return request.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, hdrs, newurl)
+        # otherwise don't sent any more requests
+        else:
+            return None
+
+    def http_error_302(self, req, fp, code, msg, hdrs):
+
+        result = request.HTTPRedirectHandler.http_error_302(
+                self, req, fp, code, msg, hdrs)
+
+        # The original http_error_302 calls self.redirect_request()
+        # If the target hostname is the same in the redirection,
+        # redirect_request() will return a new request to be handled by
+        # http_error_302 above.
+        # Otherwise, it returns None, in which case http_error_302 also returns
+        # None. In that case, we just return the response (fp) to the initial
+        # request.
+
+        if result is None:
+            return fp
+
+        # store previous responses' headers into the last result
+        for k,v in hdrs.items():
+            result.headers.set_raw(k, v)
+
+        return result
+
+    http_error_301 = http_error_303 = http_error_307 = http_error_302
 
 class Domain:
     """Domain class allows for storage of metadata on domain."""
@@ -59,7 +95,7 @@ class cdnCheck:
 
     def ip(self, dom: Domain) -> List[int]:
         """Determine IP addresses the domain resolves to."""
-        dom_list: List[str] = [dom.url, "www." + dom.url]
+        dom_list: List[str] = [dom.url]
         return_codes = []
         ip_list = []
         for domain in dom_list:
@@ -88,7 +124,7 @@ class cdnCheck:
     def cname(self, dom: Domain, timeout: int) -> List[int]:
         """Collect CNAME records on domain."""
         # List of domains to check
-        dom_list = [dom.url, "www." + dom.url]
+        dom_list = [dom.url]
         # Our codes to return
         return_code = []
         # Seutp resolver and timeouts
@@ -116,7 +152,7 @@ class cdnCheck:
     ) -> int:
         """Read 'server' header for CDN hints."""
         # List of domains with different protocols to check.
-        PROTOCOLS = ["https://", "https://www."]
+        PROTOCOLS = ["http://", "https://"]
         # Iterate through all protocols
         for PROTOCOL in PROTOCOLS:
             try:
@@ -127,8 +163,11 @@ class cdnCheck:
                     headers={"User-Agent": agent},
                 )
                 # Making the timeout 50 as to not hang thread.
-                response = request.urlopen(req, timeout=timeout)  # nosec
-            except URLError:
+                # replace RedirectHandler with RedirectFilter
+                opener = request.build_opener(RedirectFilter)
+                response = opener.open(req, timeout=timeout)
+
+            except URLError as e:
                 continue
             except RemoteDisconnected:
                 continue
@@ -143,6 +182,7 @@ class cdnCheck:
                 if interactive or verbose:
                     print(f"[{e}]: https://{dom.url}")
                 continue
+
             # Define headers to check for the response
             # to grab strings for later parsing.
             HEADERS = ["server", "via"]

--- a/src/findcdn/cdnEngine/detectCDN/cdn_check.py
+++ b/src/findcdn/cdnEngine/detectCDN/cdn_check.py
@@ -232,7 +232,7 @@ class cdnCheck:
                     dom.cdns.append(CDNs_rev[name])
                     dom.cdns_by_name.append(name)
 
-    def data_digest(self, dom: Domain) -> int:
+    def data_digest(self, dom: Domain, checks: str) -> int:
         """Digest all data collected and assign to CDN list."""
         return_code = 1
         # Iterate through all attributes for substrings
@@ -242,7 +242,7 @@ class cdnCheck:
         if len(dom.headers) > 0 and not None:
             self.CDNid(dom, dom.headers)
             return_code = 0
-        if len(dom.namesrvs) > 0 and not None:
+        if len(dom.namesrvs) > 0 and not None and 'n' in checks:
             self.CDNid(dom, dom.namesrvs)
             return_code = 0
         if len(dom.whois_data) > 0 and not None:
@@ -257,16 +257,20 @@ class cdnCheck:
         agent: str,
         verbose: bool = False,
         interactive: bool = False,
+        checks: str = "chnw",
     ) -> int:
         """Option to run everything in this library then digest."""
         # Obtain each attributes data
         self.ip(dom)
-        self.cname(dom, timeout)
-        self.https_lookup(dom, timeout, agent, interactive, verbose)
-        self.whois(dom, interactive, verbose)
+        if 'c' in checks:
+            self.cname(dom, timeout)
+        if 'h' in checks:
+            self.https_lookup(dom, timeout, agent, interactive, verbose)
+        if 'w' in checks:
+            self.whois(dom, interactive, verbose)
 
         # Digest the data
-        return_code = self.data_digest(dom)
+        return_code = self.data_digest(dom, checks)
 
         # Extra case if we want verbosity for each domain check
         if verbose:

--- a/src/findcdn/findcdn.py
+++ b/src/findcdn/findcdn.py
@@ -217,7 +217,6 @@ def interactive() -> None:
                     bool,
                     Use(lambda value: True)  # Convert to True if the flag set
                 ),
-                default=False
             ),
             "<domain>": And(
                 list, error="Please format the domains as a list."

--- a/src/findcdn/findcdn.py
+++ b/src/findcdn/findcdn.py
@@ -29,6 +29,8 @@ Options:
   --checks=<checks>            Select detection types; possible values: 
                                cname (c), HTTP headers (h), nameservers (n),
                                whois data (w). Default: "chnw"
+  --ignore                     Ignores invalid domains and only work with valid
+                               ones (default False, which stops the scan)
 """
 
 # Standard Python Libraries


### PR DESCRIPTION
# Added --checks arg

## Description

--checks can be used to select check methods to use for cdn detection

## 💭 Motivation and context ##

Certain checks can slow the detection process down unnecessarily (depending on the pipeline of course). This way, those can be disabled.

## 🧪 Testing ##

Just use the --checks argument to select the check methods needed:
  --checks=<checks>            Select detection types; possible values: 
                                              cname (c), HTTP headers (h), nameservers (n),
                                              whois data (w). Default: "chnw"

## ✅ Checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
