### PR TITLE
Modify Domain class initializer to provide fresh copies of default empty list, add test for this bug, alter old tests to remove workaround sets of list() params.

### DIFF
--- a/src/findcdn/cdnEngine/cdnEngine.py
+++ b/src/findcdn/cdnEngine/cdnEngine.py
@@ -27,9 +27,7 @@ class DomainPot:
 
         # Convert to list of type domain
         for dom in domains:
-            dom_in = detectCDN.Domain(
-                dom, list(), list(), list(), list(), list(), list(), list()
-            )
+            dom_in = detectCDN.Domain(dom)
             self.domains.append(dom_in)
 
 

--- a/src/findcdn/cdnEngine/detectCDN/cdn_check.py
+++ b/src/findcdn/cdnEngine/detectCDN/cdn_check.py
@@ -30,23 +30,23 @@ class Domain:
     def __init__(
         self,
         url: str,
-        ip: List[str] = [],
-        cnames: List[str] = [],
-        cdns: List[str] = [],
-        cdns_by_name: List[str] = [],
-        namsrvs: List[str] = [],
-        headers: List[str] = [],
-        whois_data: List[str] = [],
+        ip: List[str] = None,
+        cnames: List[str] = None,
+        cdns: List[str] = None,
+        cdns_by_name: List[str] = None,
+        namsrvs: List[str] = None,
+        headers: List[str] = None,
+        whois_data: List[str] = None        
     ):
         """Initialize object to store metadata on domain in url."""
         self.url = url
-        self.ip = ip
-        self.cnames = cnames
-        self.cdns = cdns
-        self.cdns_by_name = cdns_by_name
-        self.namesrvs = namsrvs
-        self.headers = headers
-        self.whois_data = whois_data
+        self.ip = ip or []
+        self.cnames = cnames or []
+        self.cdns = cdns or []
+        self.cdns_by_name = cdns_by_name or []
+        self.namesrvs = namsrvs or []
+        self.headers = headers or []
+        self.whois_data = whois_data or []
         self.cdn_present = False
 
 

--- a/tests/test_cdnengine.py
+++ b/tests/test_cdnengine.py
@@ -9,6 +9,52 @@ USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 
 TIMEOUT = 30
 THREADS = 0  # If 0 then cdnEngine uses CPU count to set thread count
 
+def test_domain_init():
+    """Test domain initializer to ensure that values are not being inadvertently shared 
+    between instances"""
+
+    domain1 = findcdn.cdnEngine.detectCDN.Domain("foo.absolutely.fake.zzz1")
+    domain2 = findcdn.cdnEngine.detectCDN.Domain("bar.absolutely.fake.zzz1")    
+    assert domain1.url == "foo.absolutely.fake.zzz1"
+    assert domain2.url == "bar.absolutely.fake.zzz1"
+    #ensure that both start blank
+    for d in [domain1,domain2]:
+        assert d.ip == []
+        assert d.cnames == []
+        assert d.cdns == []
+        assert d.cdns_by_name == []
+        assert d.namesrvs == []
+        assert d.headers == []
+        assert d.whois_data == []
+        assert d.cdn_present == False
+
+    #now, add some data to each field in domain1
+    domain1.ip.append("d1_ip")
+    domain1.cnames.append("d1_cnames")
+    domain1.cdns.append("d1_cdns")
+    domain1.namesrvs.append("d1_namesrvs")
+    domain1.headers.append("d1_headers")
+    domain1.whois_data.append("d1_whois_data")
+    domain1.cdn_present = True
+
+    #ensure that the domain1 has the values...
+    assert domain1.ip == ["d1_ip"]
+    assert domain1.cnames == ["d1_cnames"]
+    assert domain1.cdns == ["d1_cdns"]
+    assert domain1.namesrvs == ["d1_namesrvs"]
+    assert domain1.headers == ["d1_headers"]
+    assert domain1.whois_data == ["d1_whois_data"]
+    assert domain1.cdn_present == True
+    #and domain2 does not.
+    assert domain2.ip == []
+    assert domain2.cnames == []
+    assert domain2.cdns == []
+    assert domain2.namesrvs == []
+    assert domain2.headers == []
+    assert domain2.whois_data == []
+    assert domain2.cdn_present == False
+    
+
 
 def test_domainpot_init():
     """Test if DomainPot can be instantiated correctly."""

--- a/tests/test_detectCDN.py
+++ b/tests/test_detectCDN.py
@@ -17,8 +17,7 @@ def test_ip():
     dns.resolver.default_resolver = dns.resolver.Resolver()
     dns.resolver.default_resolver.nameservers = ["1.1.1.1", "8.8.8.8"]
     dom_in = Domain(
-        "dns.google.com", list(), list(), list(), list(), list(), list(), list()
-    )
+        "dns.google.com")
     check = cdnCheck()
     check.ip(dom_in)
 
@@ -29,16 +28,7 @@ def test_broken_ip():
     """Test a non-working domain IP resolving feature."""
     dns.resolver.default_resolver = dns.resolver.Resolver()
     dns.resolver.default_resolver.nameservers = ["1.1.1.1", "8.8.8.8"]
-    dom_in = Domain(
-        "notarealdomain.fakedomaindne.com",
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-    )
+    dom_in = Domain("notarealdomain.fakedomaindne.com")
     check = cdnCheck()
     return_code = check.ip(dom_in)
     assert return_code != 0, "This fake site should return a non 0 code."
@@ -46,9 +36,7 @@ def test_broken_ip():
 
 def test_cname():
     """Test the CNAME resolving feature."""
-    dom_in = Domain(
-        "www.asu.edu", list(), list(), list(), list(), list(), list(), list()
-    )
+    dom_in = Domain("www.asu.edu")
     check = cdnCheck()
     check.cname(dom_in, timeout=TIMEOUT)
 
@@ -59,16 +47,7 @@ def test_cname():
 
 def test_broken_cname():
     """Test a non-working domain CNAME resolving feature."""
-    dom_in = Domain(
-        "notarealdomain.fakedomaindne.com",
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-    )
+    dom_in = Domain("notarealdomain.fakedomaindne.com")
     check = cdnCheck()
     return_code = check.cname(dom_in, timeout=TIMEOUT)
     assert return_code != 0, "This fake site should return a non 0 code."
@@ -76,9 +55,7 @@ def test_broken_cname():
 
 def test_https_lookup():
     """Test the header resolving feature."""
-    dom_in = Domain(
-        "google.com", list(), list(), list(), list(), list(), list(), list()
-    )
+    dom_in = Domain("google.com")
     check = cdnCheck()
     check.https_lookup(
         dom_in, timeout=TIMEOUT, agent=USER_AGENT, interactive=False, verbose=False
@@ -89,16 +66,7 @@ def test_https_lookup():
 
 def test_broken_https_lookup():
     """Test a non-working domain header resolving feature."""
-    dom_in = Domain(
-        "notarealdomain.fakedomaindne.com",
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-    )
+    dom_in = Domain("notarealdomain.fakedomaindne.com")
     check = cdnCheck()
     check.https_lookup(
         dom_in, timeout=TIMEOUT, agent=USER_AGENT, interactive=False, verbose=False
@@ -108,9 +76,7 @@ def test_broken_https_lookup():
 
 def test_whois():
     """Test the whois resolving feature."""
-    dom_in = Domain(
-        "google.com", list(), list(), list(), list(), list(), list(), list()
-    )
+    dom_in = Domain("google.com")
     check = cdnCheck()
     check.ip(dom_in)
     check.whois(dom_in, interactive=False, verbose=False)
@@ -122,16 +88,7 @@ def test_whois():
 
 def test_broken_whois():
     """Test a non-working domain whois resolving feature."""
-    dom_in = Domain(
-        "notarealdomain.fakedomaindne.com",
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-    )
+    dom_in = Domain("notarealdomain.fakedomaindne.com")
     check = cdnCheck()
     check.ip(dom_in)
     return_code = check.whois(dom_in, interactive=False, verbose=False)
@@ -140,7 +97,7 @@ def test_broken_whois():
 
 def test_all_checks():
     """Run all checks."""
-    dom_in = Domain("login.gov", list(), list(), list(), list(), list(), list(), list())
+    dom_in = Domain("login.gov")
     check = cdnCheck()
     check.all_checks(dom_in, timeout=TIMEOUT, agent=USER_AGENT)
 
@@ -151,7 +108,7 @@ def test_all_checks():
 
 def test_all_checks_by_name():
     """Run all checks and get CDN name."""
-    dom_in = Domain("login.gov", list(), list(), list(), list(), list(), list(), list())
+    dom_in = Domain("login.gov")
     check = cdnCheck()
     check.all_checks(dom_in, timeout=TIMEOUT, agent=USER_AGENT)
 
@@ -164,16 +121,7 @@ def test_all_checks_bad():
     """Test fake domain and ensure it dosen't break anything."""
     dns.resolver.default_resolver = dns.resolver.Resolver()
     dns.resolver.default_resolver.nameservers = ["1.1.1.1", "8.8.8.8"]
-    dom = Domain(
-        "super.definitelynot.notarealdomain.fakedomaindne.com",
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-        list(),
-    )
+    dom = Domain("super.definitelynot.notarealdomain.fakedomaindne.com")
     print(dom.url, dom.cdns, dom.cnames, dom.headers, dom.whois_data, dom.ip)
     check = cdnCheck()
     return_code = check.all_checks(dom, timeout=TIMEOUT, agent=USER_AGENT)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Per issue #1 and #3, the Domain class was sharing instances of the same list based on the 'typing' initializer definition. Specifically the '[]' is evaluated at the class level and thus shared amongst all instances, since the list was not actually being created within the init function.

I've fixed this by adding an 'or' statement that adds a default value when no value is passed (from my previous experience, this supersedes the typing definition)

## 💭 Motivation and context ##

When I first checked out this code and saw the set of 
```list(),list(),list()``` I felt that this was something that could and should be fixed as often are things that require such workarounds. It turns out that it was a pretty simple change and cleans up the tests IMO.

This avoids any issues where a user of the module is manipulating multiple Domains and accidentally pollutes eachother's lists.

This specifically closes #3 and #1 

## 🧪 Testing ##

I added a new test_domain_init and fixed up previous tests that had the workaround list(),list(),list()... set of args.


<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

^ Regarding above, the tests currently do not pass, that are not directly relevant to this issue, so unsure on how to proceed.

## ✅ Pre-merge checklist ##

No dependencies were modified from the default branches.

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
